### PR TITLE
smalltalk_package.bbclass: Fix gst not finding sysroot kernel directory

### DIFF
--- a/classes/smalltalk_package.bbclass
+++ b/classes/smalltalk_package.bbclass
@@ -1,10 +1,11 @@
 DEPENDS = "smalltalk-native"
 RDEPENDS_${PN} += "smalltalk"
 GST_PACKAGE_XML ?= "package.xml"
+GST_KERNEL_DIR = "${STAGING_DIR_NATIVE}${prefix_native}/share/smalltalk/kernel"
 
 smalltalk_package_do_compile() {
-	gst < /dev/null
-	gst-package --target-directory=. ${GST_PACKAGE_XML}
+	gst --kernel-directory=${GST_KERNEL_DIR} < /dev/null
+	gst-package --kernel-directory=${GST_KERNEL_DIR} --target-directory=. ${GST_PACKAGE_XML}
 }
 
 smalltalk_package_do_install () {

--- a/recipes-smalltalk/smalltalk/smalltalk-package.inc
+++ b/recipes-smalltalk/smalltalk/smalltalk-package.inc
@@ -1,17 +1,2 @@
-DEPENDS = "smalltalk"
-
-INC_PR="r4"
-
-do_compile() {
-	gst < /dev/null
-	gst-package --target-directory=. package.xml
-}
-
-do_install () {
-	install -d ${D}${datadir}/smalltalk
-
-	install -m 0644 ${S}/*.star ${D}${datadir}/smalltalk
-} 
-
-FILES_${PN} += "${datadir}/smalltalk"
-
+inherit smalltalk_package
+INC_PR = "r5"


### PR DESCRIPTION
A recipe inheriting smalltalk_package was failing due to gst being
unable to find Builtins.st in the kernel directory.

Using strace on gst while running in the OE env showed that gst looks
for the kernel directory in /kernel and in the tmp/work/smalltalk
directory where it was built, but it doesn't look in the native sysroot
of the recipe being built, were the kernel/Builtins.st file can be
found.